### PR TITLE
Allow only .js and .ts files

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -19,7 +19,17 @@ async function uploadResources(dir, type, options){
 		return;
 	}
 
-	const entries = files.filter(value => value !== null).map( file => path.join(dir, file)).filter( file => getExt(file) !== ".json");
+	const entries = files.filter(file =>{
+		const ext = getExt(file)
+		const allowedExts = ['.js', '.ts']
+
+		if(allowedExts.includes(ext)){
+			return true
+		}
+		return false
+	}).map( file => path.join(dir, file))
+
+
 	const containsTs = files.some( file => getExt(file) === ".ts");
 	if(containsTs) {
 		const ok = await typeCheck(entries, dir);
@@ -32,7 +42,7 @@ async function uploadResources(dir, type, options){
 			return;
 		}
 	}
-	
+
 	// Build resources before reading data.
 	try{
 		await esbuild.build({
@@ -48,11 +58,11 @@ async function uploadResources(dir, type, options){
 		console.log(failedUploadError);
 		return;
 	}
-	
+
 
 	const resourceFiles = (await Promise.all(files.map( async file => {
 		try{
-			if(getExt(file) === ".json") return null;
+			if(getExt(file) !== ".js") return null;
 			const resourcePath = path.join(cwd, resourceDir, removeExt(file) + ".js");
 			const resource = await require(resourcePath);
 
@@ -73,7 +83,7 @@ async function uploadResources(dir, type, options){
 
 		// Don't log success message on first function pass.
 		if(type === "functions" && !options.fnsWithRoles) return;
-		
+
 		console.log("✔️  Successfully uploaded", type);
 		console.log();
 	}catch(err){


### PR DESCRIPTION
Hi, 
Thanks for developing this package. You save my time!

This request includes small improvements for 
- Allow only .js and .ts files and ignore all other extensions(includes dotfiles).
- Fix a bug that returns an error if there is a .DS_Store in a directory on macOS.